### PR TITLE
Initial check-in of the CDAP-Navigator integration app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+*.class
+.*.swp
+.beamer
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# Intellij Files & Dir #
+*.iml
+*.ipr
+*.iws
+atlassian-ide-plugin.xml
+out/
+.DS_Store
+./lib/
+.idea
+
+target/

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<!DOCTYPE module PUBLIC
+    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!-- This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html -->
+
+<module name="Checker">
+
+  <module name="FileTabCharacter">
+    <property name="severity" value="error"/>
+    <!-- Checks that there are no tab characters in the file.
+    -->
+  </module>
+
+  <!--
+
+  LENGTH CHECKS FOR FILES
+
+  -->
+
+  <module name="FileLength">
+    <property name="max" value="3000"/>
+    <property name="severity" value="warning"/>
+  </module>
+
+
+  <module name="NewlineAtEndOfFile">
+    <property name="lineSeparator" value="lf"/>
+  </module>
+
+  <module name="RegexpSingleline">
+    <!-- Checks that FIXME is not used in comments.  TODO is preferred.
+    -->
+    <property name="format" value="((//.*)|(\*.*))FIXME" />
+    <property name="message" value='TODO is preferred to FIXME.  e.g. "TODO: (ENG-123) -  Refactor when v2 is released."' />
+  </module>
+
+  <module name="RegexpSingleline">
+    <!-- Checks that TODOs are named with some basic formatting. Checks for the following pattern  TODO: ( 
+    -->
+    <property name="format" value="((//.*)|(\*.*))TODO[^: (]" />
+    <property name="message" value='All TODOs should be named.  e.g. "TODO: (ENG-123) - Refactor when v2 is released."' />
+  </module>
+
+  <module name="JavadocPackage">
+    <!-- Checks that each Java package has a Javadoc file used for commenting.
+      Only allows a package-info.java, not package.html. -->
+    <property name="severity" value="error"/>
+  </module>
+
+  <!-- All Java AST specific tests live under TreeWalker module. -->
+  <module name="TreeWalker">
+
+    <!-- required for SupressionCommentFilter and SuppressWithNearbyCommentFilter -->
+    <module name="FileContentsHolder"/>
+
+    <!--
+
+    IMPORT CHECKS
+
+    -->
+
+    <module name="AvoidStarImport">
+      <property name="allowClassImports" value="false"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="RedundantImport">
+      <!-- Checks for redundant import statements. -->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="ImportOrder">
+      <!-- Checks for out of order import statements. -->
+      <property name="severity" value="error"/>
+      <property name="ordered" value="true"/>
+      <property name="groups" value="/([^j]|.[^a]|..[^v]|...[^a])/,/^javax?\./"/>
+      <!-- This ensures that static imports go to the end. -->
+      <property name="option" value="bottom"/>
+      <property name="tokens" value="STATIC_IMPORT, IMPORT"/>
+    </module>
+
+    <module name="IllegalImport">
+      <property name="illegalPkgs" value="junit.framework"/>
+    </module>
+
+    <!--
+
+    METHOD LENGTH CHECKS
+
+    -->
+
+    <module name="MethodLength">
+      <property name="tokens" value="METHOD_DEF"/>
+      <property name="max" value="300"/>
+      <property name="countEmpty" value="false"/>
+      <property name="severity" value="warning"/>
+   </module>
+   
+    <!--
+
+    JAVADOC CHECKS
+
+    -->
+
+    <!-- Checks for Javadoc comments.                     -->
+    <!-- See http://checkstyle.sf.net/config_javadoc.html -->
+    <module name="JavadocMethod">
+      <property name="scope" value="protected"/>
+      <property name="severity" value="error"/>
+      <property name="allowMissingJavadoc" value="true"/>
+      <property name="allowMissingParamTags" value="true"/>
+      <property name="allowMissingReturnTag" value="true"/>
+      <property name="allowMissingThrowsTags" value="true"/>
+      <property name="allowThrowsTagsForSubclasses" value="true"/>
+      <property name="allowUndeclaredRTE" value="true"/>
+    </module>
+
+    <module name="JavadocType">
+      <property name="scope" value="protected"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="JavadocStyle">
+      <property name="severity" value="error"/>
+    </module>
+
+    <!--
+
+    NAMING CHECKS
+
+    -->
+
+    <!-- Item 38 - Adhere to generally accepted naming conventions -->
+
+    <module name="PackageName">
+      <!-- Validates identifiers for package names against the
+        supplied expression. -->
+      <!-- Here the default checkstyle rule restricts package name parts to
+        seven characters, this is not in line with common practice at Google.
+      -->
+      <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="TypeNameCheck">
+      <!-- Validates static, final fields against the
+      expression "^[A-Z][a-zA-Z0-9]*$". -->
+      <metadata name="altname" value="TypeName"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="ConstantNameCheck">
+      <!-- Validates non-private, static, final fields against the supplied
+      public/package final fields "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$". -->
+      <metadata name="altname" value="ConstantName"/>
+      <property name="applyToPublic" value="true"/>
+      <property name="applyToProtected" value="true"/>
+      <property name="applyToPackage" value="true"/>
+      <property name="applyToPrivate" value="false"/>
+      <property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|FLAG_.*)$"/>
+      <message key="name.invalidPattern"
+               value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)."/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="StaticVariableNameCheck">
+      <!-- Validates static, non-final fields against the supplied
+      expression "^[a-z][a-zA-Z0-9]*_?$". -->
+      <metadata name="altname" value="StaticVariableName"/>
+      <property name="applyToPublic" value="true"/>
+      <property name="applyToProtected" value="true"/>
+      <property name="applyToPackage" value="true"/>
+      <property name="applyToPrivate" value="true"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*_?$"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="MemberNameCheck">
+      <!-- Validates non-static members against the supplied expression. -->
+      <metadata name="altname" value="MemberName"/>
+      <property name="applyToPublic" value="true"/>
+      <property name="applyToProtected" value="true"/>
+      <property name="applyToPackage" value="true"/>
+      <property name="applyToPrivate" value="true"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="MethodNameCheck">
+      <!-- Validates identifiers for method names. -->
+      <metadata name="altname" value="MethodName"/>
+      <property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="ParameterName">
+      <!-- Validates identifiers for method parameters against the
+        expression "^[a-z][a-zA-Z0-9]*$". -->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="LocalFinalVariableName">
+      <!-- Validates identifiers for local final variables against the
+        expression "^[a-z][a-zA-Z0-9]*$". -->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="LocalVariableName">
+      <!-- Validates identifiers for local variables against the
+        expression "^[a-z][a-zA-Z0-9]*$". -->
+      <property name="severity" value="error"/>
+    </module>
+
+
+    <!--
+
+    LENGTH and CODING CHECKS
+
+    -->
+
+    <module name="LineLength">
+      <!-- Checks if a line is too long. -->
+      <property name="max" value="120" default="120"/>
+      <property name="severity" value="error"/>
+
+      <!--
+        The default ignore pattern exempts the following elements:
+          - import statements
+          - long URLs inside comments
+      -->
+
+      <property name="ignorePattern"
+          value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.ignorePattern}"
+          default="^(package .*;\s*)|(import .*;\s*)|( *\* *https?://.*)$"/>
+    </module>
+
+    <module name="LeftCurly">
+      <!-- Checks for placement of the left curly brace ('{'). -->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="RightCurly">
+      <!-- Checks right curlies on CATCH, ELSE, and TRY blocks are on
+      the same line. e.g., the following example is fine:
+      <pre>
+        if {
+          ...
+        } else
+      </pre>
+      -->
+      <!-- This next example is not fine:
+      <pre>
+        if {
+          ...
+        }
+        else
+      </pre>
+      -->
+      <property name="option" value="same"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <!-- Checks for braces around if and else blocks -->
+    <module name="NeedBraces">
+      <property name="severity" value="error"/>
+      <property name="tokens" value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
+    </module>
+
+    <module name="UpperEll">
+      <!-- Checks that long constants are defined with an upper ell.-->
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="FallThrough">
+      <!-- Warn about falling through to the next case statement.  Similar to
+      javac -Xlint:fallthrough, but the check is suppressed if a single-line comment
+      on the last non-blank line preceding the fallen-into case contains 'fall through' (or
+      some other variants which we don't publicized to promote consistency).
+      -->
+      <property name="reliefPattern"
+       value="fall through|Fall through|fallthru|Fallthru|falls through|Falls through|fallthrough|Fallthrough|No break|NO break|no break|continue on"/>
+      <property name="severity" value="error"/>
+    </module>
+
+
+    <!--
+
+    MODIFIERS CHECKS
+
+    -->
+
+    <module name="ModifierOrder">
+      <!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
+           8.4.3.  The prescribed order is:
+           public, protected, private, abstract, static, final, transient, volatile,
+           synchronized, native, strictfp
+        -->
+    </module>
+
+    <module name="RedundantModifier">
+      <!-- Checks for redundant modifiers in:
+           - interface and annotation definitions,
+           - the final modifier on methods of final classes, and
+           - inner interface declarations that are declared as static.
+        -->
+    </module>
+
+
+    <!--
+
+    WHITESPACE CHECKS
+
+    -->
+    <module name="GenericWhitespace"/>
+
+    <module name="WhitespaceAround">
+      <!-- Checks that various tokens are surrounded by whitespace.
+           This includes most binary operators and keywords followed
+           by regular or curly braces.
+      -->
+      <property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR,
+        BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
+        EQUAL, GE, GT, LAND, LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+        LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+        LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
+        MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
+        SL, SLIST, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN"/>
+      <property name="allowEmptyConstructors" value="true"/>
+      <property name="allowEmptyMethods" value="true"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="WhitespaceAfter">
+      <!-- Checks that commas, semicolons and typecasts are followed by
+           whitespace.
+      -->
+      <property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="NoWhitespaceAfter">
+      <!-- Checks that there is no whitespace after various unary operators.
+           Linebreaks are allowed.
+      -->
+      <property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
+        UNARY_PLUS"/>
+      <property name="allowLineBreaks" value="true"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="NoWhitespaceBefore">
+      <!-- Checks that there is no whitespace before various unary operators.
+           Linebreaks are allowed.
+      -->
+      <property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
+      <property name="allowLineBreaks" value="true"/>
+      <property name="severity" value="error"/>
+    </module>
+
+    <module name="ParenPad">
+      <!-- Checks that there is no whitespace before close parens or after
+           open parens.
+      -->
+      <property name="severity" value="error"/>
+    </module>
+
+  </module>
+
+  <module name="SuppressionFilter">
+    <property name="file" value="suppressions.xml"/>
+  </module>
+
+  <module name="SuppressionCommentFilter">
+    <property name="offCommentFormat" value="CHECKSTYLE OFF: (.+)" />
+    <property name="onCommentFormat" value="CHECKSTYLE ON" />
+    <property name="checkFormat" value="Javadoc.*"/>
+    <property name="messageFormat" value="$1"/>
+  </module>
+
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>co.cask.cdap.metadata</groupId>
+  <artifactId>navigator</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Navigator Metadata Application</name>
+
+  <properties>
+    <app.main.class>co.cask.cdap.metadata.NavigatorApp</app.main.class>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <cdap.version>3.3.0-SNAPSHOT</cdap.version>
+    <navigator.client.version>1.0</navigator.client.version>
+    <slf4j.version>1.7.5</slf4j.version>
+    <guava.version>13.0.1</guava.version>
+    <junit.version>4.11</junit.version>
+    <kafka.pack.version>0.9.0-SNAPSHOT</kafka.pack.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${cdap.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-kafka-flow-compat-0.8</artifactId>
+      <version>${kafka.pack.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-proto</artifactId>
+      <version>${cdap.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-unit-test</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.1.7</version>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.17</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.cloudera.navigator</groupId>
+      <artifactId>navigator-sdk-model</artifactId>
+      <version>${navigator.client.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.cloudera.navigator</groupId>
+      <artifactId>navigator-sdk-client</artifactId>
+      <version>${navigator.client.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>2.3.7</version>
+          <extensions>true</extensions>
+          <configuration>
+            <archive>
+              <manifest>
+                <mainClass>${app.main.class}</mainClass>
+              </manifest>
+            </archive>
+            <instructions>
+              <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+              <Embed-Transitive>true</Embed-Transitive>
+              <Embed-Directory>lib</Embed-Directory>
+            </instructions>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>bundle</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.14.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <version>0.10</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.doxia</groupId>
+            <artifactId>doxia-core</artifactId>
+            <version>1.6</version>
+            <exclusions>
+              <exclusion>
+                <groupId>xerces</groupId>
+                <artifactId>xercesImpl</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>rat-check</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>build-number.txt</exclude>
+                <exclude>LICENSE*.txt</exclude>
+                <exclude>*.rst</exclude>
+                <exclude>*.md</exclude>
+                <exclude>**/*.md</exclude>
+                <exclude>**/resources/**/*.properties</exclude>
+                <exclude>**/*.json.template</exclude>
+                <exclude>**/MANIFEST.MF</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>2.12.1</version>
+        <executions>
+          <execution>
+            <id>validate</id>
+            <phase>process-test-classes</phase>
+            <configuration>
+              <configLocation>checkstyle.xml</configLocation>
+              <suppressionsLocation>suppressions.xml</suppressionsLocation>
+              <encoding>UTF-8</encoding>
+              <consoleOutput>true</consoleOutput>
+              <failsOnError>true</failsOnError>
+              <includeTestSourceDirectory>true</includeTestSourceDirectory>
+            </configuration>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/main/java/co/cask/cdap/metadata/MetadataConsumer.java
+++ b/src/main/java/co/cask/cdap/metadata/MetadataConsumer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.annotation.UseDataSet;
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+import co.cask.cdap.api.flow.flowlet.OutputEmitter;
+import co.cask.cdap.kafka.flow.Kafka08ConsumerFlowlet;
+import co.cask.cdap.kafka.flow.KafkaConfigurer;
+import co.cask.cdap.kafka.flow.KafkaConsumerConfigurer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ * Subscribes to Kafka messages published for the CDAP Platform that contains the Metadata Change records.
+ */
+public final class MetadataConsumer extends Kafka08ConsumerFlowlet<ByteBuffer, ByteBuffer> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MetadataConsumer.class);
+
+  // TODO: Add a way to reset the offset?
+
+  @UseDataSet("kafkaOffsets")
+  private KeyValueTable offsetStore;
+
+  private OutputEmitter<String> emitter;
+
+  @Override
+  protected KeyValueTable getOffsetStore() {
+    return offsetStore;
+  }
+
+  @Override
+  protected void configureKafka(KafkaConfigurer kafkaConfigurer) {
+    kafkaConfigurer.setZooKeeper(getContext().getRuntimeArguments().get("kafka.zookeeper"));
+    setupTopicPartitions(kafkaConfigurer, getContext().getRuntimeArguments());
+  }
+
+  @Override
+  protected void handleInstancesChanged(KafkaConsumerConfigurer configurer) {
+    setupTopicPartitions(configurer, getContext().getRuntimeArguments());
+  }
+
+  private void setupTopicPartitions(KafkaConsumerConfigurer configurer, Map<String, String> runtimeArgs) {
+    int partitions = Integer.parseInt(runtimeArgs.get("kafka.partitions"));
+    int instanceId = getContext().getInstanceId();
+    int instances = getContext().getInstanceCount();
+    for (int i = 0; i < partitions; i++) {
+      if ((i % instances) == instanceId) {
+        configurer.addTopicPartition(runtimeArgs.get("kafka.topic"), i);
+      }
+    }
+  }
+
+  @Override
+  protected void processMessage(ByteBuffer metadataKafkaMessage) throws Exception {
+    emitter.emit(Bytes.toString(metadataKafkaMessage));
+  }
+}

--- a/src/main/java/co/cask/cdap/metadata/MetadataFlow.java
+++ b/src/main/java/co/cask/cdap/metadata/MetadataFlow.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.flow.AbstractFlow;
+
+/**
+ * Metadata Flow.
+ */
+public final class MetadataFlow extends AbstractFlow {
+
+  @Override
+  public void configure() {
+    setName("MetadataFlow");
+    setDescription("Flow that subscribes to Metadata changes and propagates the same to Navigator");
+    addFlowlet("metadataConsumer", new MetadataConsumer());
+    addFlowlet("navigatorPublisher", new NavigatorPublisher());
+    connect("metadataConsumer", "navigatorPublisher");
+  }
+}

--- a/src/main/java/co/cask/cdap/metadata/NavigatorApp.java
+++ b/src/main/java/co/cask/cdap/metadata/NavigatorApp.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.app.AbstractApplication;
+import co.cask.cdap.api.dataset.lib.KeyValueTable;
+
+/**
+ * CDAP Application that subscribes to Metadata information that are published to a Kafka Broker/Topic, by the CDAP
+ * platform, and pushes it to Cloudera Navigator.
+ */
+public class NavigatorApp extends AbstractApplication {
+
+  @Override
+  public void configure() {
+    setName("NavigatorIntegration");
+    setDescription("Application that pushes metadata to Navigator");
+    addFlow(new MetadataFlow());
+    // TODO: Get the name of the kvTable from appConfig
+    createDataset("kafkaOffsets", KeyValueTable.class);
+  }
+
+}

--- a/src/main/java/co/cask/cdap/metadata/NavigatorPublisher.java
+++ b/src/main/java/co/cask/cdap/metadata/NavigatorPublisher.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.api.annotation.ProcessInput;
+import co.cask.cdap.api.flow.flowlet.AbstractFlowlet;
+import co.cask.cdap.proto.Id;
+import co.cask.cdap.proto.codec.NamespacedIdCodec;
+import co.cask.cdap.proto.metadata.MetadataChangeRecord;
+import com.cloudera.nav.sdk.model.entities.Entity;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Deserializes {@link MetadataChangeRecord} and creates Navigator {@link Entity}s
+ * and pushes them to Navigator.
+ */
+public final class NavigatorPublisher extends AbstractFlowlet {
+  private static final Logger LOG = LoggerFactory.getLogger(NavigatorPublisher.class);
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(Id.NamespacedId.class, new NamespacedIdCodec())
+    .create();
+
+  @ProcessInput
+  public void process(String serializedMetaData) {
+    MetadataChangeRecord record = GSON.fromJson(serializedMetaData, MetadataChangeRecord.class);
+    LOG.info("Got this Metadata Change Record : {}", record);
+  }
+}

--- a/src/main/java/co/cask/cdap/metadata/entity/ApplicationEntity.java
+++ b/src/main/java/co/cask/cdap/metadata/entity/ApplicationEntity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata.entity;
+
+import co.cask.cdap.api.app.Application;
+import co.cask.cdap.proto.id.ApplicationId;
+import com.cloudera.nav.sdk.model.MD5IdGenerator;
+import com.cloudera.nav.sdk.model.SourceType;
+import com.cloudera.nav.sdk.model.entities.Entity;
+import com.cloudera.nav.sdk.model.entities.EntityType;
+
+/**
+ * CDAP {@link Application} {@link Entity}.
+ */
+public class ApplicationEntity extends Entity {
+
+  private final ApplicationId appId;
+
+  public ApplicationEntity(ApplicationId appId) {
+    this.appId = appId;
+    setName(appId.toString());
+  }
+
+  @Override
+  public SourceType getSourceType() {
+    return SourceType.HDFS;
+  }
+
+  @Override
+  public EntityType getEntityType() {
+    return EntityType.FILE;
+  }
+
+  @Override
+  public String generateId() {
+    return MD5IdGenerator.generateIdentity(appId.getNamespace(), appId.getApplication());
+  }
+}

--- a/src/main/java/co/cask/cdap/metadata/entity/DatasetEntity.java
+++ b/src/main/java/co/cask/cdap/metadata/entity/DatasetEntity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata.entity;
+
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.proto.id.DatasetId;
+import com.cloudera.nav.sdk.model.MD5IdGenerator;
+import com.cloudera.nav.sdk.model.SourceType;
+import com.cloudera.nav.sdk.model.entities.Entity;
+import com.cloudera.nav.sdk.model.entities.EntityType;
+
+/**
+ * CDAP {@link Dataset} {@link Entity}
+ */
+public class DatasetEntity extends Entity {
+
+  private final DatasetId datasetId;
+
+  public DatasetEntity(DatasetId datasetId) {
+    this.datasetId = datasetId;
+    setName(datasetId.toString());
+  }
+
+  @Override
+  public SourceType getSourceType() {
+    return SourceType.HIVE;
+  }
+
+  @Override
+  public EntityType getEntityType() {
+    return EntityType.DATASET;
+  }
+
+  @Override
+  public String generateId() {
+    return MD5IdGenerator.generateIdentity(datasetId.getNamespace(), datasetId.getDataset());
+  }
+}

--- a/src/main/java/co/cask/cdap/metadata/entity/ProgramEntity.java
+++ b/src/main/java/co/cask/cdap/metadata/entity/ProgramEntity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata.entity;
+
+import co.cask.cdap.proto.id.ProgramId;
+import com.cloudera.nav.sdk.model.MD5IdGenerator;
+import com.cloudera.nav.sdk.model.SourceType;
+import com.cloudera.nav.sdk.model.entities.Entity;
+import com.cloudera.nav.sdk.model.entities.EntityType;
+
+/**
+ * CDAP Program {@link Entity}
+ */
+public class ProgramEntity extends Entity {
+
+  private final ProgramId programId;
+
+  public ProgramEntity(ProgramId programId) {
+    this.programId = programId;
+    setName(programId.toString());
+  }
+
+  @Override
+  public SourceType getSourceType() {
+    return SourceType.YARN;
+  }
+
+  @Override
+  public EntityType getEntityType() {
+    return EntityType.SUB_OPERATION;
+  }
+
+  @Override
+  public String generateId() {
+    return MD5IdGenerator.generateIdentity(programId.getNamespace(), programId.getApplication(),
+                                           programId.getType().getPrettyName(), programId.getProgram());
+  }
+}

--- a/src/main/java/co/cask/cdap/metadata/package-info.java
+++ b/src/main/java/co/cask/cdap/metadata/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2014 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Package for HelloWorld example Application.
+ *
+ * This is a simple HelloWorld example that uses one Stream, one DataSet, one Flow and one Service.
+ * <uL>
+ *   <li>A Stream to send names to.</li>
+ *   <li>A Flow with a single Flowlet that reads the Stream and stores each name in a KeyValueTable</li>
+ *   <li>A Service that reads the name from the KeyValueTable and responds with 'Hello [Name]!'</li>
+ * </uL>
+ */
+
+package co.cask.cdap.metadata;

--- a/src/test/java/co/cask/cdap/metadata/NavigatorAppTest.java
+++ b/src/test/java/co/cask/cdap/metadata/NavigatorAppTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.metadata;
+
+import co.cask.cdap.test.ApplicationManager;
+import co.cask.cdap.test.TestBase;
+import co.cask.cdap.test.TestConfiguration;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Test for {@link NavigatorApp}.
+ */
+public class NavigatorAppTest extends TestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration("explore.enabled", false);
+
+  @Test
+  public void test() throws TimeoutException, InterruptedException, IOException {
+    // Deploy the HelloWorld application
+    ApplicationManager appManager = deployApplication(NavigatorApp.class);
+    appManager.stopAll();
+  }
+}

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright © 2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+  <suppress checks="Javadoc.*" files=".*/src/test/java/.*" />
+
+  <suppress checks="JavadocPackage" files=".*/src/(main|integration)/java/.*" />
+  <suppress checks="JavadocPackage" files=".*/src/.*/internal/.*" />
+
+  <suppress checks="JavadocStyle" files=".*/src/(main|integration)/java/.*" />
+  <suppress checks="JavadocStyle" files=".*/src/.*/internal/.*" />
+
+
+  <!-- copied from apache hadoop, won't fix style to keep diff minimal -->
+  <suppress checks=".*" files=".*/LocalJobRunnerWithFix.java" />
+
+  <!-- do not check thrift generated files -->
+  <suppress checks=".*" files=".*/transaction/distributed/thrift/.*" />
+
+
+
+</suppressions>


### PR DESCRIPTION
Initial App check-in. Mostly follows the cdap-kafka-ingest-guide app.

Approach: The app contains a Flow - which contains two flowlets. 
Source Flowlet uses kafka-pack to subscribe to metadata change messages from Kafka and sends the serialized string to the destination flowlet.
Destination Flowlet uses deserializes it back to MetadataChangeRecord and it will eventually use that to create the Entity classes required by Navigator and use the Navigator's java client to write it to Navigator.
