### PR TITLE
Update checkstyle and comment RedundantModifier

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -317,13 +317,15 @@ page at http://checkstyle.sourceforge.net/config.html -->
         -->
     </module>
 
+    <!-- Commented per Terence since there will be very little new code in this branch
     <module name="RedundantModifier">
-      <!-- Checks for redundant modifiers in:
+      <!- Checks for redundant modifiers in:
            - interface and annotation definitions,
            - the final modifier on methods of final classes, and
            - inner interface declarations that are declared as static.
-        -->
+        ->
     </module>
+    -->
 
 
     <!--
@@ -386,8 +388,14 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
   </module>
 
+  <!--
+    Optional suppression filter. It is optional because when running with Maven, it should be the
+     checkstyle plugin who provides it. It is only used when this file is used in IntelliJ.
+    -->
+
   <module name="SuppressionFilter">
     <property name="file" value="suppressions.xml"/>
+    <property name="optional" value="true"/>
   </module>
 
   <module name="SuppressionCommentFilter">

--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.12.1</version>
+        <version>2.17</version>
         <executions>
           <execution>
             <id>validate</id>
@@ -296,6 +296,13 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>6.19</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Since this branch is a bug-fix only branch, @chtyim recommended that I disable this check versus trying to fix all of the places in the code which will fail checkstyle. There was a bug in the older checkstyle that caused it to miss some of these modifiers, which has been fixed in the newer checkstyle.

This is the same as caskdata/cdap#6334 ported to this repository.

http://builds.cask.co/browse/NAV-DA2-1
