### PR TITLE
(CDAP-7826) Bump kafka compact version and remove temp fix for twill-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <slf4j.version>1.7.5</slf4j.version>
     <guava.version>13.0.1</guava.version>
     <junit.version>4.11</junit.version>
-    <kafka.pack.version>0.9.0</kafka.pack.version>
+    <kafka.pack.version>0.12.0-SNAPSHOT</kafka.pack.version>
   </properties>
 
   <distributionManagement>
@@ -186,19 +186,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!---TO DO: Remove after this JIRA is fixed: https://issues.cask.co/browse/CDAP-7826 -->
-    <dependency>
-        <groupId>org.apache.twill</groupId>
-        <artifactId>twill-core</artifactId>
-        <version>0.9.0-SNAPSHOT</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-compiler</artifactId>
-          </exclusion>
-        </exclusions>
-    </dependency>
-    <!-- END TO DO -->
   </dependencies>
 
   <build>


### PR DESCRIPTION
This needs to get merged after https://github.com/caskdata/cdap-packs/pull/79 get merged
Bump the kafka compat version to have latest twill dependency. With this, the navigator test will pass. Verified locally.